### PR TITLE
fix occasional errors when manager binds its socket

### DIFF
--- a/agent-manager/manager/lancet.py
+++ b/agent-manager/manager/lancet.py
@@ -66,6 +66,7 @@ def get_args():
 class LancetServer:
     def __init__(self, librand):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.socket.bind(("", MANAGER_PORT))
         self.socket.listen(1)
         self.controller = LancetController(librand_path=librand)


### PR DESCRIPTION
Use SO_REUSEADDR to prevent bind() from failing with OSError: [Errno 98]
Address already in use.