### PR TITLE
Use all iov buffers when measuring latency (asymmetric agents)

### DIFF
--- a/agents/tp_r2p2.c
+++ b/agents/tp_r2p2.c
@@ -278,7 +278,7 @@ static void latency_r2p2_main(void)
 		bzero(&msg, sizeof(struct r2p2_msg));
 		policy = (int)(unsigned long)to_send->meta;
 		rid = rand();
-		r2p2_prepare_msg(&msg, &to_send->iovs[0], 1, REQUEST_MSG, policy, rid);
+		r2p2_prepare_msg(&msg, to_send->iovs, to_send->iov_cnt, REQUEST_MSG, policy, rid);
 		gb = msg.head_buffer;
 
 		// randomly pick conn


### PR DESCRIPTION
In https://github.com/epfl-dcsl/lancet-tool/blob/master/agents/tp_r2p2.c#L281, the r2p2 request created from `prepare_request` is truncated to `&to_send->iovs[0]` before being passed to `r2p2_prepare_message`, which results in only 1 generic buffer being sent to the server for latency measurements.

This is a potential issue because certain application protocols (such as stss in particular) use two iov buffers, one for stss-config information and one for the actual "synthetic" payload. As such, the latency measured by the latency agent would actually not be per-request (which could be an arbitrary number of bytes long), but instead per-24byte-packet in this specific scenario. Additionally, the r2p2 sample stss server asserts that the entire request has been received, causing the server to exit/crash if vanilla installations from the lancet and r2p2 repositories are used together.

This only seems to affect the specific combination of stss application protocol with asymmetric agents (symmetric agents do not seem to have this issue, and other implemented protocols use only 1 iov buffer).

This seems to be addressable by simply changing the call to `r2p2_prepare_msg`. Making this change prevents the assertion failure in r2p2's stss server, but I encountered some issues in reproducing lancet in full so unable to do further testing. Still new to the codebase so please let me know if there is something I missed that requires a single iov buffer for latency measurements.