### PR TITLE
Enable agents to auto-select how many threads to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-.PHONY: coordinator agents style manager manager_r2p2 all clean
+.PHONY: coordinator agents style manager all clean
 
 .DEFAULT_GOAL := all
 all: agents


### PR DESCRIPTION
Since the load and latency agents are polling based, we don't want more threads than available cores to avoid errorneous measurements.

Allow -ltThreads and -loadThreads (-t at the agent command line) to take a -1 option and have the agents determine the number of threads to use.  Also, make sure at least one connection per thread exists, by checking if avalaible threads > connections and settings threads = connections.