### PR TITLE
Fix small typo in ltConns and loadConns argument of Coordinator in README. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Usage of ./coordinator/coordinator:
     	interface name for hardware timestamping (default "enp65s0")
   -loadAgents string
     	ip of loading agents separated by commas, e.g. ip1,ip2,... (this can be specified along with symAgents.  These would add additional load)
-  -loadConn int
+  -loadConns int
     	number of loading connections per agent (used for both load and sym agents) (default 1)
   -loadPattern string
     	load pattern (default "fixed:10000")
@@ -84,7 +84,7 @@ Usage of ./coordinator/coordinator:
     	latency qps (default 4000)
   -ltAgents string
     	ip of latency agents separated by commas, e.g. ip1,ip2,...
-  -ltConn int
+  -ltConns int
     	number of latency connections (default 1)
   -ltThreads int
     	latency threads per agent (default 1)


### PR DESCRIPTION
There is a typo on `ltConns` and `loadConns` argument of Coordinator in README. Better to fix that typo to keep users using this tool updated.

```
Usage of ./coordinator/coordinator:
  -agentPort int
        listening port of the agent (default 5001)
  -appProto string
        application protocol (default "echo:4")
  -ciSize int
        size of 95-confidence interval in us (default 10)
  -comProto string
        TCP|R2P2|UDP|TLS (default "TCP")
  -idist string
        interarrival distibution: fixed, exp (default "exp")
  -ifName string
        interface name for hardware timestamping (default "enp65s0")
  -loadAgents string
        ip of loading agents separated by commas, e.g. ip1,ip2,...
  -loadConns int
        number of loading connections per agent (default 1)
  -loadPattern string
        load pattern (default "fixed:10000")
  -loadThreads int
        loading threads per agent (used for load and sym agents) (default 1)
  -lqps int
        latency qps (default 4000)
  -ltAgents string
        ip of latency agents separated by commas, e.g. ip1,ip2,...
  -ltConns int
        number of latency connections (default 1)
  -ltThreads int
        latency threads per agent (default 1)
  -nicTS
        NIC timestamping for symmetric agents
  -printAgentArgs
        Print in JSON format the arguments for each agent
  -privateKey string
        location of the (local) private key to deploy the agents. Will find a default if not specified (default "$HOME/.ssh/id_rsa")
  -reqPerConn int
        Number of outstanding requests per TCP connection (default 1)
  -runAgents
        Automatically run agents (default true)
  -symAgents string
        ip of symmetric agents separated by commas, e.g. ip1,ip2,...
  -targetHost string
        host:port comma-separated list to run experiment against (default "127.0.0.1:8000")
```